### PR TITLE
ci(core): include manually minestom on modules which depends on it

### DIFF
--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 dependencies {
     api(libs.configurate.helper)
     api(libs.configurate.hocon)
-    compileOnlyApi(libs.minestom)
+    compileOnly(libs.minestom)
 
     // logging
     implementation(project(":logging"))

--- a/demo-extension/build.gradle.kts
+++ b/demo-extension/build.gradle.kts
@@ -11,9 +11,12 @@ sourceSets {
 }
 
 dependencies {
+    compileOnly(libs.minestom)
     compileOnly(project(":core"))
     compileOnly(sourceSets["dependency"].output.classesDirs)
+
     add("dependencyCompileOnly", project(":core"))
+    add("dependencyCompileOnly", libs.minestom)
 }
 
 tasks.create<Jar>("makeDependencyJar") {

--- a/lab/build.gradle.kts
+++ b/lab/build.gradle.kts
@@ -11,6 +11,7 @@ repositories {
 }
 
 dependencies {
+    compileOnly(libs.minestom)
     compileOnly(project(":core"))
 }
 

--- a/launcher-plugin/build.gradle.kts
+++ b/launcher-plugin/build.gradle.kts
@@ -4,6 +4,9 @@ plugins {
     kotlin("jvm") version "2.1.0"
 }
 
+group = "com.github.ynverxe.hexserver"
+version = "0.1.0-indev"
+
 dependencies {
     compileOnly("com.gradleup.shadow:shadow-gradle-plugin:9.0.0-beta12")
     implementation("org.spongepowered:configurate-hocon:4.0.0")

--- a/launcher/build.gradle.kts
+++ b/launcher/build.gradle.kts
@@ -5,6 +5,8 @@ plugins {
 }
 
 dependencies {
+    compileOnly(libs.minestom)
+
     // logging
     implementation(libs.adventure.slf4j)
     implementation(project(":logging"))


### PR DESCRIPTION
The developer has to choose which version of minestom he'll use, hex shouldn't use compileOnlyApi and exposing hex's minestom as a transitive dependency.