### PR TITLE
Configure gradle action

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -26,9 +26,20 @@ jobs:
       with:
         java-version: '21'
         distribution: 'temurin'
+    - name: Setup cache for Gradle
+    - uses: actions/cache@v4
+      with:
+        path: |
+          ~/.gradle/caches
+          ~/.gradle/wrapper
+        key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+        restore-keys: |
+          ${{ runner.os }}-gradle-
     - name: Setup Gradle
       uses: gradle/actions/setup-gradle@v4
     - name: Build with Gradle Wrapper
       run: ./gradlew build
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    - name: Stop Gradle Daemon
+      run: ./gradlew --stop

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -26,12 +26,8 @@ jobs:
       with:
         java-version: '21'
         distribution: 'temurin'
-
-    - name: Clone dependencies
-      run: cd .. && git clone https://github.com/Ynverxe/configurate-helper
     - name: Setup Gradle
       uses: gradle/actions/setup-gradle@v4
-
     - name: Build with Gradle Wrapper
       run: ./gradlew build
       env:

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -27,7 +27,7 @@ jobs:
         java-version: '21'
         distribution: 'temurin'
     - name: Setup cache for Gradle
-    - uses: actions/cache@v4
+      uses: actions/cache@v4
       with:
         path: |
           ~/.gradle/caches

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -29,10 +29,8 @@ jobs:
 
     - name: Clone dependencies
       run: cd .. && git clone https://github.com/Ynverxe/configurate-helper
-    # Configure Gradle for optimal use in GitHub Actions, including caching of downloaded dependencies.
-    # See: https://github.com/gradle/actions/blob/main/setup-gradle/README.md
     - name: Setup Gradle
-      uses: gradle/actions/setup-gradle@af1da67850ed9a4cedd57bfd976089dd991e2582 # v4.0.0
+      uses: gradle/actions/setup-gradle@v4
 
     - name: Build with Gradle Wrapper
       run: ./gradlew build


### PR DESCRIPTION
The project was using an outdated version of the gradle-setup action, which was causing actions to take twice as long. Version was changed to v4.